### PR TITLE
Improve Draft actions worker

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -47,6 +47,7 @@ object ApiRepository : ApiRepositoryCore() {
         method: ApiController.ApiMethod,
         body: Any? = null,
         okHttpClient: OkHttpClient = HttpClient.okHttpClient,
+        throwExceptions: Boolean = false
     ): T {
         return ApiController.callApi(url, method, body, okHttpClient, useKotlinxSerialization = true)
     }
@@ -121,8 +122,9 @@ object ApiRepository : ApiRepositoryCore() {
     fun sendDraft(mailboxUuid: String, draft: Draft): ApiResponse<Boolean> {
         val body = Json.encodeToString(draft).removeEmptyRealmLists()
 
-        fun postDraft(): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid), POST, body)
-        fun putDraft(uuid: String): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid, uuid), PUT, body)
+        fun postDraft(): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid), POST, body, throwExceptions = true)
+        fun putDraft(uuid: String): ApiResponse<Boolean> =
+            callApi(ApiRoutes.draft(mailboxUuid, uuid), PUT, body, throwExceptions = true)
 
         return draft.remoteUuid?.let(::putDraft) ?: run(::postDraft)
     }

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -111,7 +111,7 @@ object ApiRepository : ApiRepositoryCore() {
     // fun trustSender(messageResource: String): ApiResponse<EmptyResponse> = callKotlinxApi(ApiRoutes.resource("$messageResource/trustForm"), POST)
 
     fun saveDraft(mailboxUuid: String, draft: Draft): ApiResponse<SaveDraftResult> {
-        val body = Json.encodeToString(draft).removeEmptyRealmLists()
+        val body = Json.encodeToString(draft.getJsonRequestBody()).removeEmptyRealmLists()
 
         fun postDraft(): ApiResponse<SaveDraftResult> = callApi(ApiRoutes.draft(mailboxUuid), POST, body)
         fun putDraft(uuid: String): ApiResponse<SaveDraftResult> = callApi(ApiRoutes.draft(mailboxUuid, uuid), PUT, body)
@@ -120,7 +120,7 @@ object ApiRepository : ApiRepositoryCore() {
     }
 
     fun sendDraft(mailboxUuid: String, draft: Draft): ApiResponse<Boolean> {
-        val body = Json.encodeToString(draft).removeEmptyRealmLists()
+        val body = Json.encodeToString(draft.getJsonRequestBody()).removeEmptyRealmLists()
 
         fun postDraft(): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid), POST, body, throwExceptions = true)
         fun putDraft(uuid: String): ApiResponse<Boolean> =

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -47,10 +47,15 @@ object ApiRepository : ApiRepositoryCore() {
         method: ApiController.ApiMethod,
         body: Any? = null,
         okHttpClient: OkHttpClient = HttpClient.okHttpClient,
-        throwExceptions: Boolean = false
-    ): T {
-        return ApiController.callApi(url, method, body, okHttpClient, useKotlinxSerialization = true)
-    }
+        throwExceptions: Boolean = false,
+    ): T = ApiController.callApi(
+        url,
+        method,
+        body,
+        okHttpClient,
+        useKotlinxSerialization = true,
+        throwExceptions = throwExceptions,
+    )
 
     fun getAddressBooks(): ApiResponse<AddressBooksResult> = callApi(ApiRoutes.addressBooks(), GET)
 

--- a/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/api/ApiRepository.kt
@@ -47,15 +47,7 @@ object ApiRepository : ApiRepositoryCore() {
         method: ApiController.ApiMethod,
         body: Any? = null,
         okHttpClient: OkHttpClient = HttpClient.okHttpClient,
-        throwExceptions: Boolean = false,
-    ): T = ApiController.callApi(
-        url,
-        method,
-        body,
-        okHttpClient,
-        useKotlinxSerialization = true,
-        throwExceptions = throwExceptions,
-    )
+    ): T = ApiController.callApi(url, method, body, okHttpClient, true)
 
     fun getAddressBooks(): ApiResponse<AddressBooksResult> = callApi(ApiRoutes.addressBooks(), GET)
 
@@ -127,9 +119,8 @@ object ApiRepository : ApiRepositoryCore() {
     fun sendDraft(mailboxUuid: String, draft: Draft): ApiResponse<Boolean> {
         val body = Json.encodeToString(draft.getJsonRequestBody()).removeEmptyRealmLists()
 
-        fun postDraft(): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid), POST, body, throwExceptions = true)
-        fun putDraft(uuid: String): ApiResponse<Boolean> =
-            callApi(ApiRoutes.draft(mailboxUuid, uuid), PUT, body, throwExceptions = true)
+        fun postDraft(): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid), POST, body)
+        fun putDraft(uuid: String): ApiResponse<Boolean> = callApi(ApiRoutes.draft(mailboxUuid, uuid), PUT, body)
 
         return draft.remoteUuid?.let(::putDraft) ?: run(::postDraft)
     }

--- a/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/RealmDatabase.kt
@@ -68,15 +68,17 @@ object RealmDatabase {
         }
     }
 
+    val newMailboxInfoInstance get() = Realm.open(RealmConfig.mailboxInfo)
     fun mailboxInfo(): Realm = runBlocking(Dispatchers.IO) {
         mailboxInfoMutex.withLock {
-            _mailboxInfo ?: Realm.open(RealmConfig.mailboxInfo).also { _mailboxInfo = it }
+            _mailboxInfo ?: newMailboxInfoInstance.also { _mailboxInfo = it }
         }
     }
 
+    val newMailboxContentInstance get() = Realm.open(RealmConfig.mailboxContent(AccountUtils.currentMailboxId))
     fun mailboxContent(): Realm = runBlocking(Dispatchers.IO) {
         mailboxContentMutex.withLock {
-            _mailboxContent ?: Realm.open(RealmConfig.mailboxContent(AccountUtils.currentMailboxId)).also { _mailboxContent = it }
+            _mailboxContent ?: newMailboxContentInstance.also { _mailboxContent = it }
         }
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/cache/mailboxInfo/MailboxController.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/cache/mailboxInfo/MailboxController.kt
@@ -24,6 +24,7 @@ import com.infomaniak.mail.data.models.Mailbox
 import com.infomaniak.mail.data.models.Quotas
 import com.infomaniak.mail.utils.AccountUtils
 import io.realm.kotlin.MutableRealm
+import io.realm.kotlin.TypedRealm
 import io.realm.kotlin.UpdatePolicy
 import io.realm.kotlin.ext.query
 import io.realm.kotlin.notifications.ResultsChange
@@ -53,7 +54,7 @@ object MailboxController {
         return (this ?: RealmDatabase.mailboxInfo()).query<Mailbox>(checkHasUserId(userId)).query(checkIsNotInExceptions)
     }
 
-    private fun MutableRealm?.getMailboxQuery(objectId: String): RealmSingleQuery<Mailbox> {
+    private fun TypedRealm?.getMailboxQuery(objectId: String): RealmSingleQuery<Mailbox> {
         return (this ?: RealmDatabase.mailboxInfo()).query<Mailbox>("${Mailbox::objectId.name} = '$objectId'").first()
     }
 
@@ -80,7 +81,7 @@ object MailboxController {
         return realm.getMailboxesQuery(userId).asFlow()
     }
 
-    fun getMailbox(objectId: String, realm: MutableRealm? = null): Mailbox? {
+    fun getMailbox(objectId: String, realm: TypedRealm? = null): Mailbox? {
         return realm.getMailboxQuery(objectId).find()
     }
 
@@ -88,7 +89,7 @@ object MailboxController {
         return realm.getMailboxQuery(userId, mailboxId).find() ?: realm.getMailboxesQuery(userId).first().find()
     }
 
-    fun getMailboxAsync(objectId: String, realm: MutableRealm? = null): Flow<SingleQueryChange<Mailbox>> {
+    fun getMailboxAsync(objectId: String, realm: TypedRealm? = null): Flow<SingleQueryChange<Mailbox>> {
         return realm.getMailboxQuery(objectId).asFlow()
     }
     //endregion

--- a/app/src/main/java/com/infomaniak/mail/data/models/Attachment.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/Attachment.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 class Attachment : EmbeddedRealmObject {
+    var uuid: String = ""
     @SerialName("mime_type")
     var mimeType: String = ""
     var encoding: String = ""

--- a/app/src/main/java/com/infomaniak/mail/data/models/draft/Draft.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/draft/Draft.kt
@@ -19,6 +19,7 @@
 
 package com.infomaniak.mail.data.models.draft
 
+import com.infomaniak.lib.core.utils.ApiController.json
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
 import com.infomaniak.mail.data.api.RealmListSerializer
 import com.infomaniak.mail.data.cache.mailboxContent.SignatureController
@@ -34,6 +35,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.*
 import java.util.*
 
 @Serializable
@@ -126,6 +128,12 @@ class Draft : RealmObject {
         body = when (defaultSignature.position) {
             SignaturePosition.AFTER_REPLY_MESSAGE -> body + html
             else -> html + body
+        }
+    }
+
+    fun getJsonRequestBody(): MutableMap<String, JsonElement> {
+        return json.encodeToJsonElement(this).jsonObject.toMutableMap().apply {
+            this[Draft::attachments.name] = JsonArray(attachments.map { JsonPrimitive(it.uuid) })
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -173,7 +173,6 @@ class MainActivity : ThemedActivity() {
         binding.drawerLayout.setDrawerLockMode(if (isUnlocked) LOCK_MODE_UNLOCKED else LOCK_MODE_LOCKED_CLOSED)
     }
 
-    @Suppress("SpellCheckingInspection")
     private fun launchDraftsActionsWorkIfNeeded() {
         val runningWorkInfosLiveData = DraftsActionsWorker.getRunningWorkInfosLiveData(this)
         runningWorkInfosLiveData.observe(this) { worksInfoList ->

--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -173,9 +173,12 @@ class MainActivity : ThemedActivity() {
         binding.drawerLayout.setDrawerLockMode(if (isUnlocked) LOCK_MODE_UNLOCKED else LOCK_MODE_LOCKED_CLOSED)
     }
 
+    @Suppress("SpellCheckingInspection")
     private fun launchDraftsActionsWorkIfNeeded() {
-        DraftsActionsWorker.getRunningWorkInfosLiveData(this).observe(this) { worksInfoList ->
+        val runningWorkInfosLiveData = DraftsActionsWorker.getRunningWorkInfosLiveData(this)
+        runningWorkInfosLiveData.observe(this) { worksInfoList ->
             if (worksInfoList.isEmpty()) DraftsActionsWorker.scheduleWork(this)
+            runningWorkInfosLiveData.removeObservers(this)
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
@@ -156,10 +156,7 @@ fun MutableRealm.copyListToRealm(items: List<RealmObject>, alsoCopyManagedItems:
 
 //region WorkManager
 fun OneTimeWorkRequest.Builder.setExpeditedWorkRequest(): OneTimeWorkRequest.Builder {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
     return this
 }
 //endregion
-

--- a/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.utils
 
 import android.content.Context
+import android.os.Build
 import android.util.Patterns
 import android.util.TypedValue
 import android.view.View
@@ -30,6 +31,8 @@ import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.viewbinding.ViewBinding
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import com.infomaniak.lib.core.utils.*
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.mail.R
@@ -150,3 +153,13 @@ fun MutableRealm.copyListToRealm(items: List<RealmObject>, alsoCopyManagedItems:
     items.forEach { if (alsoCopyManagedItems || !it.isManaged()) copyToRealm(it, UpdatePolicy.ALL) }
 }
 //endregion
+
+//region WorkManager
+fun OneTimeWorkRequest.Builder.setExpeditedWorkRequest(): OneTimeWorkRequest.Builder {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+    }
+    return this
+}
+//endregion
+

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -33,6 +33,9 @@ import kotlinx.coroutines.withContext
 
 class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
 
+    private val mailboxContentRealm by lazy { RealmDatabase.newMailboxContentInstance }
+    private val mailboxInfoRealm by lazy { RealmDatabase.newMailboxInfoInstance }
+
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         if (runAttemptCount > MAX_RETRIES) return@withContext Result.failure()
         runCatching {
@@ -45,6 +48,9 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : Corou
                 is CancellationException -> Result.failure()
                 else -> Result.retry()
             }
+        }.also {
+            mailboxContentRealm.close()
+            mailboxInfoRealm.close()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -83,7 +83,7 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : Corou
 
             val workRequest = OneTimeWorkRequestBuilder<DraftsActionsWorker>()
                 .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
-                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .setExpeditedWorkRequest()
                 .build()
 
             WorkManager.getInstance(context).enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, workRequest)

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -101,7 +101,6 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : Corou
             WorkManager.getInstance(context).enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, workRequest)
         }
 
-        @Suppress("SpellCheckingInspection")
         fun getRunningWorkInfosLiveData(context: Context): LiveData<MutableList<WorkInfo>> {
             val workQuery = WorkQuery.Builder.fromUniqueWorkNames(listOf(TAG)).addStates(listOf(WorkInfo.State.RUNNING)).build()
             return WorkManager.getInstance(context).getWorkInfosLiveData(workQuery)

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -20,7 +20,7 @@ package com.infomaniak.mail.workers
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.work.*
-import com.infomaniak.lib.core.utils.isNetworkException
+import com.infomaniak.lib.core.utils.ApiController
 import com.infomaniak.mail.data.cache.RealmDatabase
 import com.infomaniak.mail.data.cache.mailboxContent.DraftController
 import com.infomaniak.mail.data.cache.mailboxInfo.MailboxController
@@ -76,7 +76,7 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : Corou
                 } catch (exception: Exception) {
                     exception.printStackTrace()
                     Sentry.captureException(exception)
-                    if (exception.isNetworkException()) return@writeBlocking Result.retry()
+                    if (exception is ApiController.NetworkException) return@writeBlocking Result.retry()
                     hasRemoteException = true
                 }
             }


### PR DESCRIPTION
**Fixes**
- [x] [Fix expedited work request for api before 31](https://github.com/Infomaniak/android-mail/commit/d6407b796c096882d7576c8b838625d5f550ee5a) 
> The expedited work before android 31 it creates services in the foreground and this is not what we want here

- [x] [Launch getRunningWorkInfosLiveData only once](https://github.com/Infomaniak/android-mail/commit/bbacea5773faff33187ce2b590a2d644a68c685d)
> Otherwise the service may be called back several times

- [x] [Worker with its own realms instances](https://github.com/Infomaniak/android-mail/commit/ceaaaca22bba1337d2f066f2c02d82af7a7d8dd0)
> Since the service can be in background, we don't want it to be dependent on the realm of the app, because it can create problems when the app is closed

- [x] [Manage api exceptions](https://github.com/Infomaniak/android-mail/commit/bc7162aca3bd2dc0cc54c75a0512312e5153c2d0)
> Need some modifications in `Core` to allow exceptions to be thrown from the `ApiController` whenever desired.