### PR TITLE
Set Message' subject at `null` when empty

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/draft/Draft.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/draft/Draft.kt
@@ -52,7 +52,7 @@ class Draft : RealmObject {
     var cc: RealmList<Recipient> = realmListOf()
     var bcc: RealmList<Recipient> = realmListOf()
 
-    var subject: String = ""
+    var subject: String? = null
     var body: String = ""
     var attachments: RealmList<Attachment> = realmListOf()
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -20,6 +20,9 @@
 package com.infomaniak.mail.data.models.message
 
 import android.content.Context
+import android.widget.TextView
+import androidx.annotation.StyleRes
+import androidx.core.content.res.ResourcesCompat
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.RealmInstantSerializer
@@ -42,6 +45,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.UseSerializers
+import com.infomaniak.lib.core.R as RCore
 
 @Serializable
 class Message : RealmObject {
@@ -140,11 +144,20 @@ class Message : RealmObject {
         NOT_SIGNED,
     }
 
-    fun getFormattedSubject(context: Context): Pair<String, Boolean> {
+    fun getFormattedSubject(context: Context): String {
         return if (subject.isNullOrBlank()) {
-            context.getString(R.string.noSubjectTitle) to true
+            context.getString(R.string.noSubjectTitle)
         } else {
-            subject!!.replace("\n+".toRegex(), " ") to false
+            subject!!.replace("\n+".toRegex(), " ")
+        }
+    }
+
+    fun TextView.setFormattedSubject(@StyleRes resId: Int) {
+        text = getFormattedSubject(context)
+        if (subject.isNullOrBlank()) {
+            typeface = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
+        } else {
+            setTextAppearance(resId)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -152,12 +152,12 @@ class Message : RealmObject {
         }
     }
 
-    fun TextView.setFormattedSubject(@StyleRes resId: Int) {
-        text = getFormattedSubject(context)
+    fun setFormattedSubject(textView: TextView, @StyleRes resId: Int) {
+        textView.text = getFormattedSubject(textView.context)
         if (subject.isNullOrBlank()) {
-            typeface = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
+            textView.typeface = ResourcesCompat.getFont(textView.context, RCore.font.suisseintl_regular_italic)
         } else {
-            setTextAppearance(resId)
+            textView.setTextAppearance(resId)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -19,7 +19,9 @@
 
 package com.infomaniak.mail.data.models.message
 
+import android.content.Context
 import com.infomaniak.lib.core.utils.Utils.enumValueOfOrNull
+import com.infomaniak.mail.R
 import com.infomaniak.mail.data.api.RealmInstantSerializer
 import com.infomaniak.mail.data.api.RealmListSerializer
 import com.infomaniak.mail.data.models.Attachment
@@ -138,6 +140,14 @@ class Message : RealmObject {
         NOT_SIGNED,
     }
 
+    fun getFormattedSubject(context: Context): Pair<String, Boolean> {
+        return if (subject.isNullOrBlank()) {
+            context.getString(R.string.noSubjectTitle) to true
+        } else {
+            subject!!.replace("\n+".toRegex(), " ") to false
+        }
+    }
+
     fun updateFlags(flags: MessageFlags) {
         seen = flags.seen
         isFavorite = flags.isFavorite
@@ -148,6 +158,5 @@ class Message : RealmObject {
 
     fun toThread() = Thread().apply {
         uid = this@Message.uid
-        subject = this@Message.subject
     }
 }

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -18,7 +18,9 @@
 package com.infomaniak.mail.data.models.thread
 
 import android.content.Context
+import android.widget.TextView
 import androidx.annotation.IdRes
+import androidx.annotation.StyleRes
 import com.infomaniak.lib.core.utils.*
 import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.correspondent.Recipient
@@ -115,7 +117,7 @@ class Thread : RealmObject {
 
     fun isOnlyOneDraft(): Boolean = hasDrafts && messages.count() == 1
 
-    fun getFormattedSubject(context: Context): Pair<String, Boolean> = messages.first().getFormattedSubject(context)
+    fun TextView.setFormattedSubject(@StyleRes resId: Int) = with(messages.first()) { setFormattedSubject(resId) }
 
     private fun RealmList<Recipient>.toRecipientsList(): List<Recipient> {
         return map { Recipient().initLocalValues(it.email, it.name) }

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -117,7 +117,7 @@ class Thread : RealmObject {
 
     fun isOnlyOneDraft(): Boolean = hasDrafts && messages.count() == 1
 
-    fun TextView.setFormattedSubject(@StyleRes resId: Int) = with(messages.first()) { setFormattedSubject(resId) }
+    fun setFormattedSubject(textView: TextView, @StyleRes resId: Int) = messages.first().setFormattedSubject(textView, resId)
 
     private fun RealmList<Recipient>.toRecipientsList(): List<Recipient> {
         return map { Recipient().initLocalValues(it.email, it.name) }

--- a/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/thread/Thread.kt
@@ -44,7 +44,6 @@ class Thread : RealmObject {
     var unseenMessagesCount: Int = 0
     var from: RealmList<Recipient> = realmListOf()
     var to: RealmList<Recipient> = realmListOf()
-    var subject: String? = null
     var date: RealmInstant = RealmInstant.MAX
     var size: Int = 0
     var hasAttachments: Boolean = false
@@ -115,6 +114,8 @@ class Thread : RealmObject {
     }
 
     fun isOnlyOneDraft(): Boolean = hasDrafts && messages.count() == 1
+
+    fun getFormattedSubject(context: Context): Pair<String, Boolean> = messages.first().getFormattedSubject(context)
 
     private fun RealmList<Recipient>.toRecipientsList(): List<Recipient> {
         return map { Recipient().initLocalValues(it.email, it.name) }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -26,7 +26,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -52,7 +51,6 @@ import com.infomaniak.mail.databinding.ItemThreadSeeAllButtonBinding
 import com.infomaniak.mail.ui.main.folder.ThreadListAdapter.ThreadViewHolder
 import com.infomaniak.mail.utils.*
 import kotlin.math.abs
-import com.infomaniak.lib.core.R as RCore
 
 // TODO: Do we want to extract features from LoaderAdapter (in Core) and put them here?
 // TODO: Same for all adapters in the app?
@@ -132,14 +130,7 @@ class ThreadListAdapter(
         draftPrefix.isVisible = hasDrafts
         expeditor.text = formatRecipientNames(context, if (folderRole == FolderRole.DRAFT) to else from)
 
-        val (text, isItalic) = getFormattedSubject(context)
-        mailSubject.text = text
-        if (isItalic) {
-            mailSubject.typeface = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
-        } else {
-            mailSubject.setTextAppearance(R.style.Callout)
-        }
-
+        mailSubject.setFormattedSubject(R.style.Callout)
         mailBodyPreview.text = messages.lastOrNull()?.preview?.ifBlank { root.context.getString(R.string.noBodyTitle) }
         getDisplayedRecipient(thread = this)?.let { expeditorAvatar.loadAvatar(it, contacts) }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -26,6 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -50,8 +51,8 @@ import com.infomaniak.mail.databinding.ItemThreadDateSeparatorBinding
 import com.infomaniak.mail.databinding.ItemThreadSeeAllButtonBinding
 import com.infomaniak.mail.ui.main.folder.ThreadListAdapter.ThreadViewHolder
 import com.infomaniak.mail.utils.*
-import com.infomaniak.mail.utils.Utils.getFormattedThreadSubject
 import kotlin.math.abs
+import com.infomaniak.lib.core.R as RCore
 
 // TODO: Do we want to extract features from LoaderAdapter (in Core) and put them here?
 // TODO: Same for all adapters in the app?
@@ -128,9 +129,17 @@ class ThreadListAdapter(
 
     private fun CardviewThreadItemBinding.displayThread(thread: Thread): Unit = with(thread) {
 
-        draftPrefix.isVisible = thread.hasDrafts
+        draftPrefix.isVisible = hasDrafts
         expeditor.text = formatRecipientNames(context, if (folderRole == FolderRole.DRAFT) to else from)
-        mailSubject.text = subject.getFormattedThreadSubject(root.context)
+
+        val (text, isItalic) = getFormattedSubject(context)
+        mailSubject.text = text
+        if (isItalic) {
+            mailSubject.typeface = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
+        } else {
+            mailSubject.setTextAppearance(R.style.Callout)
+        }
+
         mailBodyPreview.text = messages.lastOrNull()?.preview?.ifBlank { root.context.getString(R.string.noBodyTitle) }
         getDisplayedRecipient(thread = this)?.let { expeditorAvatar.loadAvatar(it, contacts) }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/folder/ThreadListAdapter.kt
@@ -125,12 +125,12 @@ class ThreadListAdapter(
 
     private fun getDisplayedRecipient(thread: Thread): Recipient? = thread.messages.lastOrNull()?.from?.firstOrNull()
 
-    private fun CardviewThreadItemBinding.displayThread(thread: Thread): Unit = with(thread) {
+    private fun CardviewThreadItemBinding.displayThread(thread: Thread) = with(thread) {
 
         draftPrefix.isVisible = hasDrafts
         expeditor.text = formatRecipientNames(context, if (folderRole == FolderRole.DRAFT) to else from)
 
-        mailSubject.setFormattedSubject(R.style.Callout)
+        setFormattedSubject(mailSubject, R.style.Callout)
         mailBodyPreview.text = messages.lastOrNull()?.preview?.ifBlank { root.context.getString(R.string.noBodyTitle) }
         getDisplayedRecipient(thread = this)?.let { expeditorAvatar.loadAvatar(it, contacts) }
 

--- a/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/newMessage/NewMessageViewModel.kt
@@ -53,7 +53,7 @@ class NewMessageViewModel(application: Application) : AndroidViewModel(applicati
     val mailTo = mutableListOf<Recipient>()
     val mailCc = mutableListOf<Recipient>()
     val mailBcc = mutableListOf<Recipient>()
-    var mailSubject = ""
+    var mailSubject: String? = null
     var mailBody = ""
     var mailSignature: String? = null
     val mailAttachments = mutableListOf<Attachment>()

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -276,7 +277,20 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             setOnClickListener { onMenuClicked?.invoke(message) }
         }
 
-        recipient.text = if (isExpanded) getAllRecipientsFormatted(message = this@with) else subject
+        val defaultTextAppearance = R.style.Callout_Secondary
+        if (isExpanded) {
+            recipient.text = getAllRecipientsFormatted(message = this@with)
+            recipient.setTextAppearance(defaultTextAppearance)
+        } else {
+            val (text, isItalic) = getFormattedSubject(context)
+            recipient.text = text
+            if (isItalic) {
+                recipient.typeface = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
+            } else {
+                recipient.setTextAppearance(defaultTextAppearance)
+            }
+        }
+
         recipientChevron.isVisible = isExpanded
         recipientOverlayedButton.isVisible = isExpanded
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -21,7 +21,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -277,20 +276,12 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             setOnClickListener { onMenuClicked?.invoke(message) }
         }
 
-        val defaultTextAppearance = R.style.Callout_Secondary
         if (isExpanded) {
             recipient.text = getAllRecipientsFormatted(message = this@with)
-            recipient.setTextAppearance(defaultTextAppearance)
+            recipient.setTextAppearance(R.style.Callout_Secondary)
         } else {
-            val (text, isItalic) = getFormattedSubject(context)
-            recipient.text = text
-            if (isItalic) {
-                recipient.typeface = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
-            } else {
-                recipient.setTextAppearance(defaultTextAppearance)
-            }
+            recipient.setFormattedSubject(R.style.Callout_Secondary)
         }
-
         recipientChevron.isVisible = isExpanded
         recipientOverlayedButton.isVisible = isExpanded
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadAdapter.kt
@@ -280,7 +280,7 @@ class ThreadAdapter : RecyclerView.Adapter<ThreadViewHolder>(), RealmChangesBind
             recipient.text = getAllRecipientsFormatted(message = this@with)
             recipient.setTextAppearance(R.style.Callout_Secondary)
         } else {
-            recipient.setFormattedSubject(R.style.Callout_Secondary)
+            setFormattedSubject(recipient, R.style.Callout_Secondary)
         }
         recipientChevron.isVisible = isExpanded
         recipientOverlayedButton.isVisible = isExpanded

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -22,7 +22,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -42,7 +41,6 @@ import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.RealmChangesBinding.Companion.bindListChangeToAdapter
 import kotlin.math.min
 import kotlin.math.roundToInt
-import com.infomaniak.lib.core.R as RCore
 
 class ThreadFragment : Fragment() {
 
@@ -172,14 +170,8 @@ class ThreadFragment : Fragment() {
 
     private fun onThreadUpdate(thread: Thread) = with(binding) {
 
-        val (text, isItalic) = thread.getFormattedSubject(context)
-        threadSubject.text = text
-        toolbarSubject.text = text
-        if (isItalic) {
-            val font = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
-            threadSubject.typeface = font
-            toolbarSubject.typeface = font
-        }
+        threadSubject.setFormattedSubject(R.style.H2)
+        toolbarSubject.setFormattedSubject(R.style.H2)
 
         iconFavorite.apply {
             setIconResource(if (thread.isFavorite) R.drawable.ic_star_filled else R.drawable.ic_star)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -170,8 +170,8 @@ class ThreadFragment : Fragment() {
 
     private fun onThreadUpdate(thread: Thread) = with(binding) {
 
-        threadSubject.setFormattedSubject(R.style.H2)
-        toolbarSubject.setFormattedSubject(R.style.H2)
+        thread.setFormattedSubject(threadSubject, R.style.H2)
+        thread.setFormattedSubject(toolbarSubject, R.style.H2)
 
         iconFavorite.apply {
             setIconResource(if (thread.isFavorite) R.drawable.ic_star_filled else R.drawable.ic_star)

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/ThreadFragment.kt
@@ -22,6 +22,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -39,9 +40,9 @@ import com.infomaniak.mail.databinding.FragmentThreadBinding
 import com.infomaniak.mail.ui.MainViewModel
 import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.RealmChangesBinding.Companion.bindListChangeToAdapter
-import com.infomaniak.mail.utils.Utils.getFormattedThreadSubject
 import kotlin.math.min
 import kotlin.math.roundToInt
+import com.infomaniak.lib.core.R as RCore
 
 class ThreadFragment : Fragment() {
 
@@ -171,9 +172,14 @@ class ThreadFragment : Fragment() {
 
     private fun onThreadUpdate(thread: Thread) = with(binding) {
 
-        val subject = thread.subject.getFormattedThreadSubject(context)
-        threadSubject.text = subject
-        toolbarSubject.text = subject
+        val (text, isItalic) = thread.getFormattedSubject(context)
+        threadSubject.text = text
+        toolbarSubject.text = text
+        if (isItalic) {
+            val font = ResourcesCompat.getFont(context, RCore.font.suisseintl_regular_italic)
+            threadSubject.typeface = font
+            toolbarSubject.typeface = font
+        }
 
         iconFavorite.apply {
             setIconResource(if (thread.isFavorite) R.drawable.ic_star_filled else R.drawable.ic_star)

--- a/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Utils.kt
@@ -17,19 +17,9 @@
  */
 package com.infomaniak.mail.utils
 
-import android.content.Context
-import android.text.Spanned
-import androidx.core.text.HtmlCompat
-import androidx.core.text.toSpanned
-import com.infomaniak.mail.R
 import com.infomaniak.mail.data.models.Folder
 
 object Utils {
-
-    fun String?.getFormattedThreadSubject(context: Context): Spanned {
-        return this?.replace("\n+".toRegex(), " ")?.toSpanned()
-            ?: HtmlCompat.fromHtml("<i>${context.getString(R.string.noSubjectTitle)}</i>", HtmlCompat.FROM_HTML_MODE_COMPACT)
-    }
 
     fun List<Folder>.formatFoldersListWithAllChildren(): List<Folder> {
 

--- a/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
@@ -76,7 +76,7 @@ class SyncMessagesWorker(appContext: Context, params: WorkerParameters) : BaseCo
 
     private fun Thread.showNotification(folderId: String, mailbox: Mailbox, realm: Realm) {
         MessageController.getLastMessage(uid, folderId, realm)?.let { message ->
-            val description = message.getFormattedSubject(applicationContext).first +
+            val description = message.getFormattedSubject(applicationContext) +
                     if (message.preview.isEmpty()) "" else "\n${message.preview}"
             val pendingIntent = NavDeepLinkBuilder(applicationContext)
                 .setGraph(R.navigation.main_navigation)

--- a/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
@@ -76,7 +76,8 @@ class SyncMessagesWorker(appContext: Context, params: WorkerParameters) : BaseCo
 
     private fun Thread.showNotification(folderId: String, mailbox: Mailbox, realm: Realm) {
         MessageController.getLastMessage(uid, folderId, realm)?.let { message ->
-            val description = "${message.subject}\n${message.preview}"
+            val description = message.getFormattedSubject(applicationContext).first +
+                    if (message.preview.isEmpty()) "" else "\n${message.preview}"
             val pendingIntent = NavDeepLinkBuilder(applicationContext)
                 .setGraph(R.navigation.main_navigation)
                 .setDestination(R.id.threadListFragment) // TODO : navigate to the message


### PR DESCRIPTION
When an email has no subject, the string is supposed to be `null`.
But sometimes the string isn't null, instead it's empty _(for example, when sending the email via Gmail)_.

Depends on #403 