### PR TITLE
Start sync worker with delayed duration and Avoid launching the work when it is unnecessary

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainActivity.kt
@@ -91,7 +91,8 @@ class MainActivity : ThemedActivity() {
     }
 
     override fun onStop() {
-        SyncMessagesWorker.scheduleWork(this)
+        // When you change user you don't want to launch the work
+        if (!isFinishing) SyncMessagesWorker.scheduleWork(this)
         super.onStop()
     }
 

--- a/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
@@ -91,6 +91,8 @@ class SyncMessagesWorker(appContext: Context, params: WorkerParameters) : BaseCo
         fun scheduleWork(context: Context) {
             val workRequest = PeriodicWorkRequestBuilder<SyncMessagesWorker>(MIN_PERIODIC_INTERVAL_MILLIS, TimeUnit.MILLISECONDS)
                 .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+                // We start with a delayed duration, so that when the app is rebooted the service is not launched
+                .setInitialDelay(2, TimeUnit.MINUTES)
                 .build()
 
             WorkManager.getInstance(context).enqueueUniquePeriodicWork(TAG, ExistingPeriodicWorkPolicy.REPLACE, workRequest)


### PR DESCRIPTION
**Enhancements**
 - Start the SyncMessagesWork with an initial delay
 - Avoid to launch the work if it's unnecessary, It happens especially when you change user