### PR TITLE
fix: not redirected to the right email notification when there is many

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
@@ -92,7 +92,7 @@ class SyncMessagesWorker(appContext: Context, params: WorkerParameters) : BaseCo
         val intent = Intent(applicationContext, LaunchActivity::class.java).clearStack().apply {
             putExtras(LaunchActivityArgs(uid, userId, mailbox.mailboxId).toBundle())
         }
-        val contentIntent = PendingIntent.getActivity(applicationContext, 0, intent, pendingIntentFlags)
+        val contentIntent = PendingIntent.getActivity(applicationContext, uid.hashCode(), intent, pendingIntentFlags)
 
         applicationContext.showNewMessageNotification(mailbox.channelId, message.sender.name, description).apply {
             setSubText(mailbox.email)


### PR DESCRIPTION
**Fix**
When clicking on a notification it was always the same sender request in the notification `pendintIntent`, so when clicking it was always the last update of the `pendingIntent` that was used