### PR TITLE
RealmChangesBinding can now check if the content has been changed in the ui

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/RealmChangesBinding.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/RealmChangesBinding.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.recyclerview.widget.RecyclerView
+import com.infomaniak.mail.utils.RealmChangesBinding.OnRealmChanged
 import io.realm.kotlin.notifications.*
 import io.realm.kotlin.types.BaseRealmObject
 import io.realm.kotlin.types.RealmObject
@@ -30,6 +31,8 @@ import io.realm.kotlin.types.RealmObject
  *
  * This adapter will automatically handle any updates to its data and call `notifyDataSetChanged()`,
  * `notifyItemInserted()`, `notifyItemRemoved()` or `notifyItemRangeChanged()` as appropriate.
+ * In case there are changes but we want to notify them only if needed,
+ * we can override the [OnRealmChanged.areContentsTheSame] method.
  *
  * The RealmAdapter will stop receiving updates if the Realm instance providing the [ResultsChange] or [ListChange] is
  * closed.

--- a/app/src/main/java/com/infomaniak/mail/utils/RealmChangesBinding.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/RealmChangesBinding.kt
@@ -169,7 +169,7 @@ class RealmChangesBinding<T : BaseRealmObject, VH : RecyclerView.ViewHolder> pri
                 count++
             }
         }
-        // if we finish the iteration and we still have some modifications to notify, we treat them here
+        // If we finish the iteration and we still have some modifications to notify, we treat them here
         if (count > 0) recyclerViewAdapter.notifyItemRangeChanged(start, count)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/RealmChangesBinding.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/RealmChangesBinding.kt
@@ -137,19 +137,26 @@ class RealmChangesBinding<T : BaseRealmObject, VH : RecyclerView.ViewHolder> pri
                 recyclerViewAdapter.notifyItemRangeChanged(changeRange.startIndex, changeRange.length)
             } else {
                 runCatching {
+                    // We will avoid notifying each item in a row, instead we will notify by range while we can.
+                    // To do this, we count the number of changes in a row, then as soon as we have a different element
+                    // we notify the previous ones with a notification by range.
                     var start = changeRange.startIndex
                     var count = 0
                     for (index in changeRange.startIndex until changeRange.length) {
                         if (onRealmChanged.areContentsTheSame(previousList[index], newList[index])) {
+                            // The content has not changed so there is no need to notify the adapter.
+                            // However, if we had changes previously, we will notify them.
                             if (count > 0) {
                                 recyclerViewAdapter.notifyItemRangeChanged(start, count)
                                 count = 0
                             }
                         } else {
+                            // For the first change we get its index in start and then we count the number of changes
                             if (count == 0) start = index
                             count++
                         }
                     }
+                    // if we finish the iteration and we still have some modifications to notify, we treat them here
                     if (count > 0) recyclerViewAdapter.notifyItemRangeChanged(start, count)
                 }.onFailure {
                     recyclerViewAdapter.notifyItemRangeChanged(changeRange.startIndex, changeRange.length)


### PR DESCRIPTION
**Description**
Currently it is realm that takes care of updating our ui.
But there are some cases where we have realm changes but we don't want the ui to be updated.

**Fix**
This solution adds a feature that will prevent `RealmChangesBinding` to check if the content has really changed before notifying by overriding the `areContentsTheSame` method from the adapter