### PR TITLE
Fix force refresh mailboxes when cancelled

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/MainViewModel.kt
@@ -48,6 +48,7 @@ import com.infomaniak.mail.utils.SharedViewModelUtils.refreshFolders
 import com.infomaniak.mail.utils.Utils.formatFoldersListWithAllChildren
 import com.infomaniak.mail.utils.getFoldersIds
 import com.infomaniak.mail.utils.getUids
+import com.infomaniak.mail.utils.handlerIO
 import com.infomaniak.mail.workers.DraftsActionsWorker
 import io.realm.kotlin.ext.copyFromRealm
 import kotlinx.coroutines.Dispatchers
@@ -180,7 +181,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         DraftsActionsWorker.scheduleWork(context)
     }
 
-    fun forceRefreshMailboxes() = viewModelScope.launch(Dispatchers.IO) {
+    fun forceRefreshMailboxes() = viewModelScope.launch(viewModelScope.handlerIO) {
         Log.d(TAG, "Force refresh mailboxes")
         val mailboxes = ApiRepository.getMailboxes().data ?: return@launch
         MailboxController.updateMailboxes(context, mailboxes)

--- a/app/src/main/java/com/infomaniak/mail/utils/CoroutineScopeUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/CoroutineScopeUtils.kt
@@ -1,0 +1,36 @@
+/*
+ * Infomaniak kMail - Android
+ * Copyright (C) 2023 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils
+
+import io.sentry.Sentry
+import kotlinx.coroutines.*
+
+inline val CoroutineScope.handlerIO get() = handler + Dispatchers.IO
+inline val Job.handlerIO get() = handler + Dispatchers.IO
+
+inline val CoroutineScope.handler
+    get() = CoroutineExceptionHandler { _, exception ->
+        if (isActive) Sentry.captureException(exception)
+        exception.printStackTrace()
+    }
+
+inline val Job.handler
+    get() = CoroutineExceptionHandler { _, exception ->
+        if (isActive) Sentry.captureException(exception)
+        exception.printStackTrace()
+    }


### PR DESCRIPTION
-  [fix: forceRefreshMailboxes not stopped while it's cancelled](https://github.com/Infomaniak/android-mail/commit/cbbce24b04d95557fe3faa8aa427c071df673081)
- feat: [add coroutine scope utils](https://github.com/Infomaniak/android-mail/commit/cf43800232b266796abcec2db51b894b7876ae92)

**Exception**
```
io.realm.kotlin.exceptions.RealmException: [7]: Accessing object of type Mailbox which has been invalidated or deleted
        at io.realm.kotlin.internal.CoreExceptionConverter$initialize$1.invoke(RealmInteropBridge.kt:119)
        at io.realm.kotlin.internal.CoreExceptionConverter$initialize$1.invoke(RealmInteropBridge.kt:118)
        at io.realm.kotlin.internal.interop.CoreErrorConverter.convertCoreError(CoreErrorConverter.kt:27)
        at io.realm.kotlin.internal.interop.CoreErrorUtils.coreErrorAsThrowable(CoreErrorUtils.kt:24)
        at io.realm.kotlin.internal.interop.realmcJNI.realm_get_value(Native Method)
        at io.realm.kotlin.internal.interop.realmc.realm_get_value(realmc.java:650)
        at io.realm.kotlin.internal.interop.RealmInterop.realm_get_value-Kih35ds(RealmInterop.kt:437)
        at com.infomaniak.mail.data.models.Mailbox.isLimited(Mailbox.kt:1639)
        at com.infomaniak.mail.ui.MainViewModel.updateCurrentMailboxQuotas(MainViewModel.kt:198)
        at com.infomaniak.mail.ui.MainViewModel.access$updateCurrentMailboxQuotas(MainViewModel.kt:59)
        at com.infomaniak.mail.ui.MainViewModel$forceRefreshMailboxes$1.invokeSuspend(MainViewModel.kt:187)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
        at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
        Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@fb7160, Dispatchers.IO]
    Caused by: io.realm.kotlin.internal.interop.RealmCoreInvalidatedObjectException: [7]: Accessing object of type Mailbox which has been invalidated or deleted
        at io.realm.kotlin.internal.interop.CoreErrorUtils.coreErrorAsThrowable(CoreErrorUtils.kt:33)
```