### PR TITLE
fix:  setPreviousMessage in draft with incorrect thread

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
+++ b/app/src/main/java/com/infomaniak/mail/data/models/message/Message.kt
@@ -178,7 +178,7 @@ class Message : RealmObject {
             cc = cc + cleanedCc
         }
 
-        if (to.isEmpty()) to = from
+        if (to.isEmpty()) to = from.detachedFromRealm()
 
         return to to cc
     }


### PR DESCRIPTION
Fix sentry https://sentry.infomaniak.com/share/issue/c814b67d1e2343728dcf34a02dbfadfa/
```bash
io.realm.kotlin.exceptions.RealmException: [6]: Realm accessed from incorrect thread.
at io.realm.kotlin.internal.CoreExceptionConverter$initialize$1.invoke(RealmInteropBridge.kt:119)
at io.realm.kotlin.internal.CoreExceptionConverter$initialize$1.invoke(RealmInteropBridge.kt:118)
at io.realm.kotlin.internal.interop.CoreErrorConverter.convertCoreError(CoreErrorConverter.kt:27)
at io.realm.kotlin.internal.interop.CoreErrorUtils.coreErrorAsThrowable(CoreErrorUtils.kt:24)
at io.realm.kotlin.internal.interop.realmcJNI.realm_get_value(Native Method)
at io.realm.kotlin.internal.interop.realmc.realm_get_value(realmc.java:650)
at io.realm.kotlin.internal.interop.RealmInterop.realm_get_value-Kih35ds(RealmInterop.kt:437)
at com.infomaniak.mail.data.models.correspondent.Recipient.getEmail(Recipient.kt:55)
at com.infomaniak.mail.data.models.correspondent.Recipient.hashCode(Recipient.kt:46)
at java.util.HashMap.hash(HashMap.java:338)
at java.util.HashMap.put(HashMap.java:611)
at java.util.HashSet.add(HashSet.java:219)
at com.infomaniak.mail.ui.main.newMessage.RecipientFieldView.initRecipients(RecipientFieldView.kt:227)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment.populateUiWithViewModel(NewMessageFragment.kt:226)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment.access$populateUiWithViewModel(NewMessageFragment.kt:68)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment$initDraftAndViewModel$1.invoke(NewMessageFragment.kt:141)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment$initDraftAndViewModel$1.invoke(NewMessageFragment.kt:138)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment.initDraftAndViewModel$lambda$5(NewMessageFragment.kt:138)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment.$r8$lambda$jNwERMdnuDDtJ1-lYSEr1bA1BWI(Unknown Source:0)
at com.infomaniak.mail.ui.main.newMessage.NewMessageFragment$$ExternalSyntheticLambda5.onChanged(Unknown Source:2)
at androidx.lifecycle.LiveData.considerNotify(LiveData.java:133)
at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:151)
at androidx.lifecycle.LiveData.setValue(LiveData.java:309)
at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
at androidx.lifecycle.LiveDataScopeImpl$emit$2.invokeSuspend(CoroutineLiveData.kt:101)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
at android.os.Handler.handleCallback(Handler.java:942)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:201)
at android.os.Looper.loop(Looper.java:288)
at android.app.ActivityThread.main(ActivityThread.java:7872)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@7027553,
Dispatchers.IO]
**Caused by**: io.realm.kotlin.internal.interop.RealmCoreWrongThreadException: [6]: Realm accessed from incorrect thread.
at io.realm.kotlin.internal.interop.CoreErrorUtils.coreErrorAsThrowable(CoreErrorUtils.kt:32)
```