### PR TITLE
fix: ForegroundServiceStartNotAllowedException

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/Extensions.kt
@@ -194,13 +194,6 @@ fun Fragment.safeNavigateToNewMessageActivity(draftMode: DraftMode, messageUid: 
 }
 //endregion
 
-//region WorkManager
-fun OneTimeWorkRequest.Builder.setExpeditedWorkRequest(): OneTimeWorkRequest.Builder {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-    return this
-}
-//endregion
-
 //region API
 inline fun <reified T> ApiResponse<T>.throwErrorAsException() {
     throw error?.exception ?: Exception(ApiController.json.encodeToString(this))

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.mail.workers
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.work.*
 import com.infomaniak.lib.core.api.ApiController
@@ -38,8 +39,11 @@ import com.infomaniak.mail.data.models.Folder.FolderRole
 import com.infomaniak.mail.data.models.Mailbox
 import com.infomaniak.mail.data.models.draft.Draft
 import com.infomaniak.mail.data.models.draft.Draft.DraftAction
-import com.infomaniak.mail.utils.*
+import com.infomaniak.mail.utils.AccountUtils
+import com.infomaniak.mail.utils.LocalStorageUtils
+import com.infomaniak.mail.utils.NotificationUtils
 import com.infomaniak.mail.utils.NotificationUtils.showDraftActionsNotification
+import com.infomaniak.mail.utils.throwErrorAsException
 import io.realm.kotlin.MutableRealm
 import io.sentry.Sentry
 import kotlinx.coroutines.Dispatchers
@@ -67,6 +71,8 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
     private var userId: Int by Delegates.notNull()
 
     override suspend fun launchWork(): Result = withContext(Dispatchers.IO) {
+        Log.d(TAG, "Work started")
+
         if (DraftController.getDraftsWithActionsCount(mailboxContentRealm) == 0L) return@withContext Result.success()
         if (AccountUtils.currentMailboxId == AppSettings.DEFAULT_ID) return@withContext Result.failure()
 
@@ -76,19 +82,18 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
         mailbox = MailboxController.getMailbox(userId, mailboxId, mailboxInfoRealm) ?: return@withContext Result.failure()
         okHttpClient = AccountUtils.getHttpClient(userId)
 
-        moveServiceToForeground()
-
         handleDraftsActions()
     }
 
     override fun onFinish() {
         mailboxContentRealm.close()
         mailboxInfoRealm.close()
+        Log.d(TAG, "Work finished")
     }
 
-    private suspend fun moveServiceToForeground() {
-        applicationContext.showDraftActionsNotification().apply {
-            setForeground(ForegroundInfo(NotificationUtils.DRAFT_ACTIONS_ID, build()))
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        return applicationContext.showDraftActionsNotification().run {
+            ForegroundInfo(NotificationUtils.DRAFT_ACTIONS_ID, build())
         }
     }
 
@@ -99,6 +104,8 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
         val isFailure = mailboxContentRealm.writeBlocking {
 
             val drafts = DraftController.getDraftsWithActions(realm = this).ifEmpty { return@writeBlocking false }
+
+            Log.d(TAG, "handleDraftsActions: ${drafts.count()} draft to handle")
 
             var hasRemoteException = false
 
@@ -228,12 +235,14 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
             if (AccountUtils.currentMailboxId == AppSettings.DEFAULT_ID) return
             if (DraftController.getDraftsWithActionsCount() == 0L) return
 
+            Log.d(TAG, "Work scheduled")
+
             val workData = workDataOf(USER_ID_KEY to AccountUtils.currentUserId, MAILBOX_ID_KEY to AccountUtils.currentMailboxId)
             val workRequest = OneTimeWorkRequestBuilder<DraftsActionsWorker>()
                 .addTag(TAG)
                 .setInputData(workData)
                 .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
-                .setExpeditedWorkRequest()
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
 
             WorkManager.getInstance(context).enqueueUniqueWork(TAG, ExistingWorkPolicy.APPEND_OR_REPLACE, workRequest)

--- a/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/DraftsActionsWorker.kt
@@ -105,7 +105,7 @@ class DraftsActionsWorker(appContext: Context, params: WorkerParameters) : BaseC
 
             val drafts = DraftController.getDraftsWithActions(realm = this).ifEmpty { return@writeBlocking false }
 
-            Log.d(TAG, "handleDraftsActions: ${drafts.count()} draft to handle")
+            Log.d(TAG, "handleDraftsActions: ${drafts.count()} drafts to handle")
 
             var hasRemoteException = false
 


### PR DESCRIPTION
fix sentry https://sentry.infomaniak.com/share/issue/fd357ea10c0f4ce891480b989d44688c/

**Description**
> Apps that target Android 12 (API level 31) or higher can't start foreground services while running in the background, except for [a few special cases](https://developer.android.com/guide/components/foreground-services#background-start-restriction-exemptions). If an app tries to start a foreground service while the app runs in the background, and the foreground service doesn't satisfy one of the exceptional cases, the system throws a [ForegroundServiceStartNotAllowedException](https://developer.android.com/reference/android/app/ForegroundServiceStartNotAllowedException).

https://developer.android.com/guide/components/foreground-services#background-start-restrictions