### PR TITLE
Fix `markAsReadUnread` back navigation when closed

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ActionsBottomSheetDialog.kt
@@ -116,9 +116,9 @@ abstract class ActionsBottomSheetDialog : BottomSheetDialogFragment() {
         setText(favoriteText)
     }
 
-    private fun ActionItemView.setClosingOnClickListener(forceQuit: Boolean = false, callback: (() -> Unit)) {
+    private fun ActionItemView.setClosingOnClickListener(callback: (() -> Unit)) {
         setOnClickListener {
-            with(findNavController()) { if (forceQuit) popBackStack(R.id.threadListFragment, false) else popBackStack() }
+            findNavController().popBackStack()
             callback()
         }
     }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ActionsBottomSheetDialog.kt
@@ -67,7 +67,7 @@ abstract class ActionsBottomSheetDialog : BottomSheetDialogFragment() {
         archive.isGone = mainViewModel.isCurrentFolderRole(FolderRole.ARCHIVE)
 
         archive.setClosingOnClickListener { onClickListener.onArchive() }
-        markAsReadUnread.setOnClickListener { onClickListener.onReadUnread() }
+        markAsReadUnread.setClosingOnClickListener { onClickListener.onReadUnread() }
         move.setClosingOnClickListener { onClickListener.onMove() }
         postpone.setClosingOnClickListener { onClickListener.onPostpone() }
         favorite.setClosingOnClickListener { onClickListener.onFavorite() }

--- a/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/mail/ui/main/thread/actions/ThreadActionsBottomSheetDialog.kt
@@ -78,7 +78,7 @@ class ThreadActionsBottomSheetDialog : ActionsBottomSheetDialog() {
 
                 override fun onReadUnread() {
                     mainViewModel.toggleSeenStatus(threadUid)
-                    findNavController().popBackStack(R.id.threadListFragment, false)
+                    findNavController().popBackStack(R.id.threadFragment, true)
                 }
 
                 override fun onMove() {


### PR DESCRIPTION
`markAsReadUnread` for a Message now correctly closes the BottomSheetDialog
`markAsReadUnread` for a Thread now pop to the entry before ThreadFragment (could be ThreadListFragment or SearchFragment)