### PR TITLE
Split Body history from Message

### DIFF
--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -44,6 +44,16 @@ object MessageBodyUtils {
         return MessageBodyQuote(messageBody = body, quote = quote)
     }
 
+    private fun handleBlockQuote(htmlDocumentWithoutQuote: Document, htmlQuotes: MutableList<Element>) {
+        var quotedContentElements = htmlDocumentWithoutQuote.selectFirst(blockquote)
+
+        while (quotedContentElements != null) {
+            htmlQuotes.add(quotedContentElements)
+            quotedContentElements.remove()
+            quotedContentElements = htmlDocumentWithoutQuote.selectFirst(blockquote)
+        }
+    }
+
     private fun handleQuoteDescriptors(htmlDocumentWithoutQuote: Document, htmlQuotes: MutableList<Element>): String {
         var currentQuoteDescriptor = ""
         for (quoteDescriptor in quoteDescriptors) {
@@ -58,20 +68,10 @@ object MessageBodyUtils {
         return currentQuoteDescriptor
     }
 
-    private fun handleBlockQuote(htmlDocumentWithoutQuote: Document, htmlQuotes: MutableList<Element>) {
-        var quotedContentElements = htmlDocumentWithoutQuote.selectFirst(blockquote)
-
-        while (quotedContentElements != null) {
-            htmlQuotes.add(quotedContentElements)
-            quotedContentElements.remove()
-            quotedContentElements = htmlDocumentWithoutQuote.selectFirst(blockquote)
-        }
-    }
-
     private fun splitBodyAndQuote(
         htmlQuotes: MutableList<Element>,
         htmlDocumentWithQuote: Document,
-        currentQuoteDescriptor: String
+        currentQuoteDescriptor: String,
     ): Pair<String, String?> {
         return htmlQuotes.lastOrNull()?.let { htmlQuote ->
             val quotedContentElements = htmlDocumentWithQuote.select(currentQuoteDescriptor)

--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -25,7 +25,7 @@ object MessageBodyUtils {
 
     private const val blockquote = "blockquote"
 
-    private val quoteDescriptors = listOf(
+    private val quoteDescriptors = arrayOf(
         ".ik_mail_quote",
         ".gmail_extra",
         ".gmail_quote",
@@ -35,7 +35,7 @@ object MessageBodyUtils {
     fun splitBodyAndQuote(messageBody: String): MessageBodyQuote {
         val htmlDocumentWithQuote = Jsoup.parse(messageBody)
         val htmlDocumentWithoutQuote = Jsoup.parse(messageBody)
-        val htmlQuotes: MutableList<Element> = mutableListOf()
+        val htmlQuotes = mutableListOf<Element>()
 
         handleBlockQuote(htmlDocumentWithoutQuote, htmlQuotes)
         val currentQuoteDescriptor = handleQuoteDescriptors(htmlDocumentWithoutQuote, htmlQuotes).ifEmpty { blockquote }
@@ -73,23 +73,23 @@ object MessageBodyUtils {
         htmlDocumentWithQuote: Document,
         currentQuoteDescriptor: String
     ): Pair<String, String?> {
-        return htmlQuotes.lastOrNull()?.let {
+        return htmlQuotes.lastOrNull()?.let { htmlQuote ->
             val quotedContentElements = htmlDocumentWithQuote.select(currentQuoteDescriptor)
             if (currentQuoteDescriptor == blockquote) {
                 for (quoteElement in quotedContentElements) {
-                    if (quoteElement.toString() == it.toString()) {
+                    if (quoteElement.toString() == htmlQuote.toString()) {
                         quoteElement.remove()
                         break
                     }
                 }
-                htmlDocumentWithQuote.toString() to it.toString()
+                htmlDocumentWithQuote.toString() to htmlQuote.toString()
             } else {
                 val firstQuotedContent = quotedContentElements.first()
                 firstQuotedContent?.remove()
                 htmlDocumentWithQuote.toString() to firstQuotedContent.toString()
             }
 
-            htmlDocumentWithQuote.toString() to it.toString()
+            htmlDocumentWithQuote.toString() to htmlQuote.toString()
         } ?: (htmlDocumentWithQuote.toString() to null)
     }
 

--- a/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
+++ b/app/src/main/java/com/infomaniak/mail/utils/MessageBodyUtils.kt
@@ -1,0 +1,100 @@
+/*
+ * Infomaniak kMail - Android
+ * Copyright (C) 2023 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.mail.utils
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+object MessageBodyUtils {
+
+    private const val blockquote = "blockquote"
+
+    private val quoteDescriptors = listOf(
+        ".ik_mail_quote",
+        ".gmail_extra",
+        ".gmail_quote",
+        ".yahoo_quoted",
+    )
+
+    fun splitBodyAndQuote(messageBody: String): MessageBodyQuote {
+        val htmlDocumentWithQuote = Jsoup.parse(messageBody)
+        val htmlDocumentWithoutQuote = Jsoup.parse(messageBody)
+        val htmlQuotes: MutableList<Element> = mutableListOf()
+
+        handleBlockQuote(htmlDocumentWithoutQuote, htmlQuotes)
+        val currentQuoteDescriptor = handleQuoteDescriptors(htmlDocumentWithoutQuote, htmlQuotes).ifEmpty { blockquote }
+
+        val (body, quote) = splitBodyAndQuote(htmlQuotes, htmlDocumentWithQuote, currentQuoteDescriptor)
+        return MessageBodyQuote(messageBody = body, quote = quote)
+    }
+
+    private fun handleQuoteDescriptors(htmlDocumentWithoutQuote: Document, htmlQuotes: MutableList<Element>): String {
+        var currentQuoteDescriptor = ""
+        for (quoteDescriptor in quoteDescriptors) {
+            val quotedContentElement = htmlDocumentWithoutQuote.select(quoteDescriptor).first()
+            if (quotedContentElement != null) {
+                htmlQuotes.add(quotedContentElement)
+                quotedContentElement.remove()
+                currentQuoteDescriptor = quoteDescriptor
+                break
+            }
+        }
+        return currentQuoteDescriptor
+    }
+
+    private fun handleBlockQuote(htmlDocumentWithoutQuote: Document, htmlQuotes: MutableList<Element>) {
+        var quotedContentElements = htmlDocumentWithoutQuote.selectFirst(blockquote)
+
+        while (quotedContentElements != null) {
+            htmlQuotes.add(quotedContentElements)
+            quotedContentElements.remove()
+            quotedContentElements = htmlDocumentWithoutQuote.selectFirst(blockquote)
+        }
+    }
+
+    private fun splitBodyAndQuote(
+        htmlQuotes: MutableList<Element>,
+        htmlDocumentWithQuote: Document,
+        currentQuoteDescriptor: String
+    ): Pair<String, String?> {
+        return htmlQuotes.lastOrNull()?.let {
+            val quotedContentElements = htmlDocumentWithQuote.select(currentQuoteDescriptor)
+            if (currentQuoteDescriptor == blockquote) {
+                for (quoteElement in quotedContentElements) {
+                    if (quoteElement.toString() == it.toString()) {
+                        quoteElement.remove()
+                        break
+                    }
+                }
+                htmlDocumentWithQuote.toString() to it.toString()
+            } else {
+                val firstQuotedContent = quotedContentElements.first()
+                firstQuotedContent?.remove()
+                htmlDocumentWithQuote.toString() to firstQuotedContent.toString()
+            }
+
+            htmlDocumentWithQuote.toString() to it.toString()
+        } ?: (htmlDocumentWithQuote.toString() to null)
+    }
+
+    data class MessageBodyQuote(
+        val messageBody: String,
+        val quote: String?,
+    )
+}

--- a/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
@@ -147,7 +147,7 @@ class SyncMessagesWorker(appContext: Context, params: WorkerParameters) : BaseCo
 
         val subject = applicationContext.formatSubject(message.subject)
         val preview = message.body?.value?.ifBlank { null }
-            ?.let { "\n${MessageBodyUtils.splitBodyAndQuote(it).messageBody.htmlToText()}" }
+            ?.let { "\n${MessageBodyUtils.splitBodyAndQuote(it).messageBody.htmlToText().trim()}" }
             ?: message.preview.ifBlank { null }?.let { "\n${it.trim()}" }
             ?: ""
         val formattedPreview = preview.replace(multipleWhitespaces, "\n") // Ignore multiple/start whitespaces

--- a/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
+++ b/app/src/main/java/com/infomaniak/mail/workers/SyncMessagesWorker.kt
@@ -40,12 +40,9 @@ import com.infomaniak.mail.data.models.Mailbox
 import com.infomaniak.mail.data.models.thread.Thread
 import com.infomaniak.mail.ui.LaunchActivity
 import com.infomaniak.mail.ui.LaunchActivityArgs
-import com.infomaniak.mail.utils.AccountUtils
-import com.infomaniak.mail.utils.ApiErrorException
+import com.infomaniak.mail.utils.*
 import com.infomaniak.mail.utils.ApiErrorException.*
 import com.infomaniak.mail.utils.NotificationUtils.showNewMessageNotification
-import com.infomaniak.mail.utils.formatSubject
-import com.infomaniak.mail.utils.htmlToText
 import io.realm.kotlin.Realm
 import io.sentry.Sentry
 import kotlinx.coroutines.Dispatchers
@@ -150,7 +147,7 @@ class SyncMessagesWorker(appContext: Context, params: WorkerParameters) : BaseCo
 
         val subject = applicationContext.formatSubject(message.subject)
         val preview = message.body?.value?.ifBlank { null }
-            ?.let { "\n${it.htmlToText().trim()}" } // TODO: remove body history
+            ?.let { "\n${MessageBodyUtils.splitBodyAndQuote(it).messageBody.htmlToText()}" }
             ?: message.preview.ifBlank { null }?.let { "\n${it.trim()}" }
             ?: ""
         val formattedPreview = preview.replace(multipleWhitespaces, "\n") // Ignore multiple/start whitespaces


### PR DESCRIPTION
**Features**
- feat: Add an utility to separate the message and its history [MessageBodyUtils.kt](https://github.com/Infomaniak/android-mail/compare/split-body-history-from-message?expand=1#diff-592fa659ebf4dff67cd29f268e4b6358f1a46c2dd270ffad58abbbb4ec154bda)
- feat: Only show body messages for notifications